### PR TITLE
feat(frontend): add layout convention to router

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@types/node": "^22.7.2",
     "@types/react": "^18.3.9",
     "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.2",
     "@vitejs/plugin-react-refresh": "^1.3.1",
     "@wyw-in-js/vite": "^0.5.4",
     "prettier": "3.3.3",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@types/react": "^18.3.9",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.2",
-    "@vitejs/plugin-react-refresh": "^1.3.1",
     "@wyw-in-js/vite": "^0.5.4",
     "prettier": "3.3.3",
     "typescript": "^5.6.2",

--- a/src/pages/sonic.tsx
+++ b/src/pages/sonic.tsx
@@ -19,7 +19,9 @@ const Sonic: React.FC = () => {
 export default Sonic;
 
 export const layout: React.FC = () => {
-  return <>
-    <Outlet />
-  </>;
-}
+  return (
+    <>
+      <Outlet />
+    </>
+  );
+};

--- a/src/pages/sonic.tsx
+++ b/src/pages/sonic.tsx
@@ -1,5 +1,6 @@
-import React from "react";
+import type React from "react";
 import Widget from "../components/common/widgets/widget.component";
+import { Outlet } from "react-router-dom";
 
 const Sonic: React.FC = () => {
   return (
@@ -16,3 +17,9 @@ const Sonic: React.FC = () => {
 };
 
 export default Sonic;
+
+export const layout: React.FC = () => {
+  return <>
+    <Outlet />
+  </>;
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,8 +1,6 @@
 import { lazy, Suspense } from "react";
 import { createBrowserRouter } from "react-router-dom";
 
-const ContentView = lazy(() => import("./components/contentView.component"));
-
 export type BBPage = {
   default: React.FC;
   layout?: React.FC;
@@ -13,30 +11,30 @@ const imported_pages = import.meta.glob("./pages/**/*.tsx") as Record<
   () => Promise<BBPage>
 >;
 
-const regex_route_start_matches = /\.\//;
-const regex_route_path_matches =
-  /\/(src|pages|index|home|components|routes)|(\.tsx|\.component.tsx)$/g;
-const regex_slug_matches = /\[\.{3}.+\]/;
-const regex_slug_value_matches = /\[(.+)\]/;
-
 async function lazyLoadPage(path: string) {
   const { default: Component, layout } = await imported_pages[path]();
   return { Component, layout };
 }
 
 async function lazyLoadPageWithLayout(path: string) {
-  const { layout } = await imported_pages[path]();
+  const { layout } = await lazyLoadPage(path);
   if (!layout) return import("./components/contentView.component");
 
   return { default: layout! };
 }
 
+const regexRouteMatchStartPath = /\.\//;
+const regexRouteMatchComponentName =
+  /\/(src|pages|index|home|components|routes)|(\.tsx|\.component.tsx)$/g;
+const regexRouteMatchTripleDotSlug = /\[\.{3}.+\]/;
+const regexRouteMatchSlugName = /\[(.+)\]/;
+
 const routes = Object.keys(imported_pages).map((page) => {
   const path = page
-    .replace(regex_route_start_matches, "/")
-    .replace(regex_route_path_matches, "")
-    .replace(regex_slug_matches, "*")
-    .replace(regex_slug_value_matches, ":$1");
+    .replace(regexRouteMatchStartPath, "/") // replaces the ./ at the start of the path with a /
+    .replace(regexRouteMatchComponentName, "") // strips the .tsx or .component.tsx, etc from the end of the path
+    .replace(regexRouteMatchTripleDotSlug, "*") // replaces [...] with *
+    .replace(regexRouteMatchSlugName, ":$1"); // replaces [paramName] with :paramName
 
   const LayoutElement = lazy(() => lazyLoadPageWithLayout(page));
   return {

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,39 +1,46 @@
-import { lazy } from "react";
+import { lazy, Suspense } from "react";
 import { createBrowserRouter } from "react-router-dom";
 
 const ContentView = lazy(() => import("./components/contentView.component"));
 
-const imported_routes = import.meta.glob("./pages/**/*.tsx", {
-  import: "default",
-});
-const regex_home_route_matches = /\.\/pages\/home.tsx$/;
+export type BBPage = {
+  default: React.FC;
+  layout?: React.FC;
+}
+
+const imported_pages = import.meta.glob("./pages/**/*.tsx") as Record<string, () => Promise<BBPage>>;
+
 const regex_route_start_matches = /\.\//;
 const regex_route_path_matches =
   /\/(src|pages|index|home|components|routes)|(\.tsx|\.component.tsx)$/g;
 const regex_slug_matches = /\[\.{3}.+\]/;
 const regex_slug_value_matches = /\[(.+)\]/;
 
-async function lazyLoad(path: string) {
-  const Component = (await imported_routes[path]()) as React.FC;
-  return { Component };
+async function lazyLoadPage(path: string) {
+  const { default: Component, layout } = (await imported_pages[path]());
+  return { Component, layout };
 }
 
-const routes = Object.keys(imported_routes).map((route) => {
-  if (regex_home_route_matches.test(route))
-    return {
-      element: <ContentView />,
-      children: [{ path: "/", lazy: () => lazyLoad(route) }],
-    };
-  const path = route
+async function lazyLoadPageWithLayout(path: string) {
+  const { layout } = (await imported_pages[path]());
+  if (!layout) return import("./components/contentView.component");
+
+  return { default: layout! };
+}
+
+const routes = Object.keys(imported_pages).map((page) => {
+  const path = page
     .replace(regex_route_start_matches, "/")
     .replace(regex_route_path_matches, "")
     .replace(regex_slug_matches, "*")
     .replace(regex_slug_value_matches, ":$1");
 
-  //return { path, lazy: () => lazyLoad(route) };
+  const LayoutElement = lazy(() => lazyLoadPageWithLayout(page));
   return {
-    element: <ContentView />,
-    children: [{ path: path, lazy: () => lazyLoad(route) }],
+    element: <Suspense fallback={<div>Loading...</div>}><LayoutElement /></Suspense>,
+    children: [{
+      path: path, lazy: () => lazyLoadPage(page),
+    }],
   };
 });
 

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -6,9 +6,12 @@ const ContentView = lazy(() => import("./components/contentView.component"));
 export type BBPage = {
   default: React.FC;
   layout?: React.FC;
-}
+};
 
-const imported_pages = import.meta.glob("./pages/**/*.tsx") as Record<string, () => Promise<BBPage>>;
+const imported_pages = import.meta.glob("./pages/**/*.tsx") as Record<
+  string,
+  () => Promise<BBPage>
+>;
 
 const regex_route_start_matches = /\.\//;
 const regex_route_path_matches =
@@ -17,12 +20,12 @@ const regex_slug_matches = /\[\.{3}.+\]/;
 const regex_slug_value_matches = /\[(.+)\]/;
 
 async function lazyLoadPage(path: string) {
-  const { default: Component, layout } = (await imported_pages[path]());
+  const { default: Component, layout } = await imported_pages[path]();
   return { Component, layout };
 }
 
 async function lazyLoadPageWithLayout(path: string) {
-  const { layout } = (await imported_pages[path]());
+  const { layout } = await imported_pages[path]();
   if (!layout) return import("./components/contentView.component");
 
   return { default: layout! };
@@ -37,10 +40,17 @@ const routes = Object.keys(imported_pages).map((page) => {
 
   const LayoutElement = lazy(() => lazyLoadPageWithLayout(page));
   return {
-    element: <Suspense fallback={<div>Loading...</div>}><LayoutElement /></Suspense>,
-    children: [{
-      path: path, lazy: () => lazyLoadPage(page),
-    }],
+    element: (
+      <Suspense fallback={<div>Loading...</div>}>
+        <LayoutElement />
+      </Suspense>
+    ),
+    children: [
+      {
+        path: path,
+        lazy: () => lazyLoadPage(page),
+      },
+    ],
   };
 });
 

--- a/src/vite.config.ts
+++ b/src/vite.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from "vite";
-import reactRefresh from "@vitejs/plugin-react-refresh";
+import react from "@vitejs/plugin-react";
 import linaria from "@wyw-in-js/vite";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
-    reactRefresh(),
+    react(),
     linaria({
       include: ["**/*.{ts,tsx}"],
       babelOptions: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "vite";
-import react from '@vitejs/plugin-react';
+import react from "@vitejs/plugin-react";
 import linaria from "@wyw-in-js/vite";
 
 // https://vitejs.dev/config/
@@ -10,7 +10,7 @@ export default defineConfig({
       include: ["**/*.{ts,tsx}"],
       babelOptions: {
         presets: ["@babel/preset-typescript", "@babel/preset-react"],
-      }
+      },
     }),
   ],
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,16 +1,16 @@
 import { defineConfig } from "vite";
-import reactRefresh from "@vitejs/plugin-react-refresh";
+import react from '@vitejs/plugin-react';
 import linaria from "@wyw-in-js/vite";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
-    reactRefresh(),
+    react(),
     linaria({
       include: ["**/*.{ts,tsx}"],
       babelOptions: {
         presets: ["@babel/preset-typescript", "@babel/preset-react"],
-      },
+      }
     }),
   ],
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,7 +32,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.14.8, @babel/core@npm:^7.22.15, @babel/core@npm:^7.22.5, @babel/core@npm:^7.23.5":
+"@babel/core@npm:^7.14.8, @babel/core@npm:^7.22.15, @babel/core@npm:^7.22.5, @babel/core@npm:^7.23.5, @babel/core@npm:^7.25.2":
   version: 7.25.2
   resolution: "@babel/core@npm:7.25.2"
   dependencies:
@@ -1079,7 +1079,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-react-jsx-self@npm:^7.14.5":
+"@babel/plugin-transform-react-jsx-self@npm:^7.14.5, @babel/plugin-transform-react-jsx-self@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-transform-react-jsx-self@npm:7.24.7"
   dependencies:
@@ -1090,7 +1090,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-react-jsx-source@npm:^7.14.5":
+"@babel/plugin-transform-react-jsx-source@npm:^7.14.5, @babel/plugin-transform-react-jsx-source@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-transform-react-jsx-source@npm:7.24.7"
   dependencies:
@@ -2263,6 +2263,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vitejs/plugin-react@npm:^4.3.2":
+  version: 4.3.2
+  resolution: "@vitejs/plugin-react@npm:4.3.2"
+  dependencies:
+    "@babel/core": "npm:^7.25.2"
+    "@babel/plugin-transform-react-jsx-self": "npm:^7.24.7"
+    "@babel/plugin-transform-react-jsx-source": "npm:^7.24.7"
+    "@types/babel__core": "npm:^7.20.5"
+    react-refresh: "npm:^0.14.2"
+  peerDependencies:
+    vite: ^4.2.0 || ^5.0.0
+  checksum: 10c0/945f357175bea45031dc98d379e63cd34cd60a51b3dd394b66138696625ac8b55bc913a23481f78bbe15ca558c21ea4699b936abbd8242003d7c0ad51d298727
+  languageName: node
+  linkType: hard
+
 "@wyw-in-js/processor-utils@npm:0.5.4, @wyw-in-js/processor-utils@npm:^0.5.3":
   version: 0.5.4
   resolution: "@wyw-in-js/processor-utils@npm:0.5.4"
@@ -2341,6 +2356,7 @@ __metadata:
     "@types/node": "npm:^22.7.2"
     "@types/react": "npm:^18.3.9"
     "@types/react-dom": "npm:^18.3.0"
+    "@vitejs/plugin-react": "npm:^4.3.2"
     "@vitejs/plugin-react-refresh": "npm:^1.3.1"
     "@wyw-in-js/vite": "npm:^0.5.4"
     axios: "npm:^1.7.7"
@@ -3921,6 +3937,13 @@ __metadata:
   version: 0.10.0
   resolution: "react-refresh@npm:0.10.0"
   checksum: 10c0/616e82bed3787bf4e55dcc1c9836f251b93523dd4b0ffb1c24c2dcf5d09f686fbf3cffc7d489cd7f12429f76ddf66eb431748fc07df56b18a888a7705cbc079e
+  languageName: node
+  linkType: hard
+
+"react-refresh@npm:^0.14.2":
+  version: 0.14.2
+  resolution: "react-refresh@npm:0.14.2"
+  checksum: 10c0/875b72ef56b147a131e33f2abd6ec059d1989854b3ff438898e4f9310bfcc73acff709445b7ba843318a953cb9424bcc2c05af2b3d80011cee28f25aef3e2ebb
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,7 +32,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.14.8, @babel/core@npm:^7.22.15, @babel/core@npm:^7.22.5, @babel/core@npm:^7.23.5, @babel/core@npm:^7.25.2":
+"@babel/core@npm:^7.22.15, @babel/core@npm:^7.22.5, @babel/core@npm:^7.23.5, @babel/core@npm:^7.25.2":
   version: 7.25.2
   resolution: "@babel/core@npm:7.25.2"
   dependencies:
@@ -1079,7 +1079,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-react-jsx-self@npm:^7.14.5, @babel/plugin-transform-react-jsx-self@npm:^7.24.7":
+"@babel/plugin-transform-react-jsx-self@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-transform-react-jsx-self@npm:7.24.7"
   dependencies:
@@ -1090,7 +1090,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-react-jsx-source@npm:^7.14.5, @babel/plugin-transform-react-jsx-source@npm:^7.24.7":
+"@babel/plugin-transform-react-jsx-source@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-transform-react-jsx-source@npm:7.24.7"
   dependencies:
@@ -1963,16 +1963,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/pluginutils@npm:^4.1.1":
-  version: 4.2.1
-  resolution: "@rollup/pluginutils@npm:4.2.1"
-  dependencies:
-    estree-walker: "npm:^2.0.1"
-    picomatch: "npm:^2.2.2"
-  checksum: 10c0/3ee56b2c8f1ed8dfd0a92631da1af3a2dfdd0321948f089b3752b4de1b54dc5076701eadd0e5fc18bd191b77af594ac1db6279e83951238ba16bf8a414c64c48
-  languageName: node
-  linkType: hard
-
 "@rollup/pluginutils@npm:^5.0.4, @rollup/pluginutils@npm:^5.1.2":
   version: 5.1.2
   resolution: "@rollup/pluginutils@npm:5.1.2"
@@ -2250,19 +2240,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitejs/plugin-react-refresh@npm:^1.3.1":
-  version: 1.3.6
-  resolution: "@vitejs/plugin-react-refresh@npm:1.3.6"
-  dependencies:
-    "@babel/core": "npm:^7.14.8"
-    "@babel/plugin-transform-react-jsx-self": "npm:^7.14.5"
-    "@babel/plugin-transform-react-jsx-source": "npm:^7.14.5"
-    "@rollup/pluginutils": "npm:^4.1.1"
-    react-refresh: "npm:^0.10.0"
-  checksum: 10c0/991c714beca345f3693ff61409b2c5a8c63b1c09e8f5c71af9f107173889a97a57b1a209c92b8a20113028114e1206971fb3acc85a608f249ff5cf2d103db7fa
-  languageName: node
-  linkType: hard
-
 "@vitejs/plugin-react@npm:^4.3.2":
   version: 4.3.2
   resolution: "@vitejs/plugin-react@npm:4.3.2"
@@ -2357,7 +2334,6 @@ __metadata:
     "@types/react": "npm:^18.3.9"
     "@types/react-dom": "npm:^18.3.0"
     "@vitejs/plugin-react": "npm:^4.3.2"
-    "@vitejs/plugin-react-refresh": "npm:^1.3.1"
     "@wyw-in-js/vite": "npm:^0.5.4"
     axios: "npm:^1.7.7"
     bootstrap: "npm:^5.3.3"
@@ -2964,7 +2940,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"estree-walker@npm:^2.0.1, estree-walker@npm:^2.0.2":
+"estree-walker@npm:^2.0.2":
   version: 2.0.2
   resolution: "estree-walker@npm:2.0.2"
   checksum: 10c0/53a6c54e2019b8c914dc395890153ffdc2322781acf4bd7d1a32d7aedc1710807bdcd866ac133903d5629ec601fbb50abe8c2e5553c7f5a0afdd9b6af6c945af
@@ -3790,7 +3766,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.2.2, picomatch@npm:^2.3.1":
+"picomatch@npm:^2.3.1":
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
   checksum: 10c0/26c02b8d06f03206fc2ab8d16f19960f2ff9e81a658f831ecb656d8f17d9edc799e8364b1f4a7873e89d9702dff96204be0fa26fe4181f6843f040f819dac4be
@@ -3930,13 +3906,6 @@ __metadata:
   version: 2.0.2
   resolution: "react-property@npm:2.0.2"
   checksum: 10c0/27a3dfa68d29d45fc3582552715203291d26c6f1b228fdb6775e7ca19b10753141dbe98a0aa3a4da745b39fcd7427dc2d623055e63742062231ee18692a6f0fa
-  languageName: node
-  linkType: hard
-
-"react-refresh@npm:^0.10.0":
-  version: 0.10.0
-  resolution: "react-refresh@npm:0.10.0"
-  checksum: 10c0/616e82bed3787bf4e55dcc1c9836f251b93523dd4b0ffb1c24c2dcf5d09f686fbf3cffc7d489cd7f12429f76ddf66eb431748fc07df56b18a888a7705cbc079e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Adds convention to where pages export a property named `layout`, which is a React component that can be lazily loaded if need be.
- Closes #21 
- Updates vite config to use [@vitejs/plugin-react](https://www.npmjs.com/package/@vitejs/plugin-react) over [@vitejs/plugin-react-refresh](https://www.npmjs.com/package/@vitejs/plugin-react-refresh) as the package was deprecated.