### PR TITLE
chore: add dependabutt

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,13 +9,43 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "javascript"
+      - "automerge" # 👈 This label can be used by the auto-merge workflow
+    open-pull-requests-limit: 5
+    allow:
+      - dependency-type: "direct"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"
+      - "automerge" # 👈 This label can be used by the auto-merge workflow
+    open-pull-requests-limit: 5
+    allow:
+      - dependency-type: "direct"
 
   - package-ecosystem: "devcontainers"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "devcontainers"
+      - "automerge" # 👈 This label can be used by the auto-merge workflow
+    open-pull-requests-limit: 5
+    allow:
+      - dependency-type: "direct"

--- a/.github/workflows/dependabutt-handler.yml
+++ b/.github/workflows/dependabutt-handler.yml
@@ -3,11 +3,11 @@ on:
   workflow_run:
     workflows: ["CI"]
     types: [completed]
-    
+
 permissions:
   contents: read
   pull-requests: write
-  
+
 jobs:
   call-automerge:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}


### PR DESCRIPTION
I created this workflow in <https://github.com/ZFGCCP/github-workflows/blob/b48139fb52a9e3c27cc01fdfeea99bf7130403bc/.github/workflows/workflow-auto-merge-security-updates.yml> that auto merges dependabot stuff. I'm just annoyed and tired of it, so if we have a CI that works, then we could safely just merge stuff.